### PR TITLE
makes map updatable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,26 @@ import Marker from './Marker';
 
 const GoogleMapContainer = withGoogleMap(props => <GoogleMap {...props} ref={props.handleMapMounted} />);
 
+/**
+ * Calculates the zoom for the map object using long/lat deltas
+ * @param {*} region : an object containing the longitude and latitude deltas
+ * @returns integer
+ */
 function calcZoom(region) {
   if (!region.latitudeDelta || !region.longitudeDelta) return 13
   const avgDelta = (region.longitudeDelta + region.latitudeDelta) / 2.0;
   return Math.floor(1/avgDelta);
 }
+
 class MapView extends PureComponent {
+  static defaultProps = {
+    // Sets default location to Washington D.C. if region prop not supplied
+    region: {
+      latitude: 38.8935128,
+      longitude: -77.1546602
+    }
+  };
+
   handleMapMounted = map => (this.map = map);
 
   onDragEnd = () => {
@@ -20,17 +34,13 @@ class MapView extends PureComponent {
   };
 
   render() {
-    if (!this.props.region)
-      return (
-        <View style={styles.container}>
-          <ActivityIndicator />
-        </View>
-      );
-    const center = { 
-      lat: this.props.region.latitude, 
-      lng: this.props.region.longitude 
+    const { region } = this.props;
+
+    const center = {
+      lat: region.latitude,
+      lng: region.longitude
     };
-    const zoom = calcZoom(this.props.region);
+    const zoom = calcZoom(region);
     return (
       <View style={styles.container}>
         <GoogleMapContainer
@@ -60,3 +70,4 @@ const styles = StyleSheet.create({
 
 export { Marker };
 export default MapView;
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { withGoogleMap, GoogleMap } from 'react-google-maps';
 import Marker from './Marker';
 
 const GoogleMapContainer = withGoogleMap(props => <GoogleMap {...props} ref={props.handleMapMounted} />);
 
-class MapView extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { center: { lat: props.region.latitude, lng: props.region.longitude } };
-  }
-
+function calcZoom(region) {
+  if (!region.latitudeDelta || !region.longitudeDelta) return 13
+  const avgDelta = (region.longitudeDelta + region.latitudeDelta) / 2.0;
+  return Math.floor(1/avgDelta);
+}
+class MapView extends PureComponent {
   handleMapMounted = map => (this.map = map);
 
   onDragEnd = () => {
@@ -20,22 +20,27 @@ class MapView extends Component {
   };
 
   render() {
-    if (!this.state.center)
+    if (!this.props.region)
       return (
         <View style={styles.container}>
           <ActivityIndicator />
         </View>
       );
+    const center = { 
+      lat: this.props.region.latitude, 
+      lng: this.props.region.longitude 
+    };
+    const zoom = calcZoom(this.props.region);
     return (
       <View style={styles.container}>
         <GoogleMapContainer
           handleMapMounted={this.handleMapMounted}
           containerElement={<div style={{ height: '100%' }} />}
           mapElement={<div style={{ height: '100%' }} />}
-          center={this.state.center}
+          center={center}
           onDragStart={!!this.props.onRegionChange && this.props.onRegionChange}
           onDragEnd={this.onDragEnd}
-          defaultZoom={15}
+          zoom={zoom}
           onClick={this.props.onPress}
         >
           {this.props.children}
@@ -53,4 +58,5 @@ const styles = StyleSheet.create({
   },
 });
 
+export { Marker };
 export default MapView;


### PR DESCRIPTION
This PR addresses two issue:

1. When trying to be compatible with the react-native-maps API, the main index needs to export `Marker` as a named export.
2. The original implementation did not account for changing the center location of a map nor adjusting the zoom level programmatically, this PR allows for both of those things.