### PR TITLE
Add named exports for MapView's static components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,12 @@ MapView.Marker = Marker;
 MapView.Polyline = Polyline;
 MapView.Callout = Callout;
 
+export {
+  Marker,
+  Polyline,
+  Callout
+}
+
 const styles = StyleSheet.create({
   container: {
     height: '100%',


### PR DESCRIPTION
This closes #34, since `react-native-maps` uses named exports.