### PR TITLE
Add named exports for Marker, Polyline and Callout elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,8 @@ MapView.Marker = Marker;
 MapView.Polyline = Polyline;
 MapView.Callout = Callout;
 
+export { Marker, Polyline, Callout };
+
 const styles = StyleSheet.create({
   container: {
     height: '100%',


### PR DESCRIPTION
Closes https://github.com/react-native-web-community/react-native-web-maps/issues/34
Created this PR since https://github.com/react-native-web-community/react-native-web-maps/pull/37 ci checks didn't pass and the PR was not updated